### PR TITLE
:rocket: Change API endpoint query in order to show UFs ordered by name

### DIFF
--- a/web/src/pages/CreatePoint/index.tsx
+++ b/web/src/pages/CreatePoint/index.tsx
@@ -64,7 +64,7 @@ const CreatePoint = () => {
   }, []);
 
   useEffect(() => {
-    axios.get<IBGEUFResponse[]>('https://servicodados.ibge.gov.br/api/v1/localidades/estados').then(response => {
+    axios.get<IBGEUFResponse[]>('https://servicodados.ibge.gov.br/api/v1/localidades/estados?orderBy=nome').then(response => {
       const ufInitials = response.data.map(uf => uf.sigla);
 
       setUfs(ufInitials);


### PR DESCRIPTION
Tomei essa mudança pois é mais fácil pro usuário encontrar sua respectiva UF se todas elas estiverem sendo listadas em ordem alfabética.